### PR TITLE
Expose batch decode info

### DIFF
--- a/src/records.rs
+++ b/src/records.rs
@@ -108,17 +108,33 @@ pub struct RecordBatchEncoder;
 /// Batch decoder for Kafka records.
 pub struct RecordBatchDecoder;
 
-struct BatchDecodeInfo {
-    record_count: usize,
-    timestamp_type: TimestampType,
-    min_offset: i64,
-    min_timestamp: i64,
-    base_sequence: i32,
-    transactional: bool,
-    control: bool,
-    partition_leader_epoch: i32,
-    producer_id: i64,
-    producer_epoch: i16,
+/// Metadata from a record batch header, decoded without decompressing record data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchDecodeInfo {
+    /// Number of records in this batch.
+    pub record_count: i32,
+    /// Indicates whether timestamps represent record creation or log append time.
+    pub timestamp_type: TimestampType,
+    /// Base offset of the batch.
+    pub min_offset: i64,
+    /// Timestamp of the first record in the batch.
+    pub min_timestamp: i64,
+    /// Base sequence number for idempotent producers.
+    pub base_sequence: i32,
+    /// Whether this batch is part of a transaction.
+    pub transactional: bool,
+    /// Whether this batch contains control records.
+    pub control: bool,
+    /// Epoch of the partition leader at the time of writing.
+    pub partition_leader_epoch: i32,
+    /// Producer ID for idempotent/transactional producers.
+    pub producer_id: i64,
+    /// Producer epoch for idempotent/transactional producers.
+    pub producer_epoch: i16,
+    /// Compression algorithm used for record data in this batch.
+    pub compression: Compression,
+    /// Record batch format version (magic byte).
+    pub version: i8,
 }
 
 /// Decoded records plus information about compression.
@@ -470,27 +486,41 @@ impl RecordBatchDecoder {
         }?;
         Ok((version, compression))
     }
+    /// Decode batch headers for all record batches in the buffer without decompressing records.
+    ///
+    /// Useful for inspecting metadata (record counts, offsets, producer info, compression) on
+    /// raw `records` bytes from [`FetchResponse`](crate::messages::fetch_response::FetchResponse)
+    /// or [`ProduceRequest`](crate::messages::produce_request::ProduceRequest) partitions.
+    pub fn decode_batch_info<B: ByteBuf>(buf: &mut B) -> Result<Vec<BatchDecodeInfo>> {
+        let mut headers = Vec::new();
+        while buf.has_remaining() {
+            let version = buf.try_peek_bytes(MAGIC_BYTE_OFFSET..(MAGIC_BYTE_OFFSET + 1))?[0] as i8;
+            if version != 2 {
+                break; // legacy message sets not supported
+            }
+            let (header, _records) = Self::decode_batch_header_inner(buf, version)?;
+            headers.push(header);
+        }
+        Ok(headers)
+    }
+
     fn decode_new_records<B: ByteBuf>(
         buf: &mut B,
         batch_decode_info: &BatchDecodeInfo,
         version: i8,
         records: &mut Vec<Record>,
     ) -> Result<()> {
-        records.reserve(batch_decode_info.record_count);
+        records.reserve(batch_decode_info.record_count as usize);
         for _ in 0..batch_decode_info.record_count {
             records.push(Record::decode_new(buf, batch_decode_info, version)?);
         }
         Ok(())
     }
-    fn decode_new_batch<B: ByteBuf, F>(
+
+    fn decode_batch_header_inner<B: ByteBuf>(
         buf: &mut B,
         version: i8,
-        records: &mut Vec<Record>,
-        decompress_func: Option<&F>,
-    ) -> Result<Compression>
-    where
-        F: Fn(&mut bytes::Bytes, Compression) -> Result<B>,
-    {
+    ) -> Result<(BatchDecodeInfo, Bytes)> {
         // Base offset
         let min_offset = types::Int64.decode(buf)?;
 
@@ -565,9 +595,8 @@ impl RecordBatchDecoder {
         if record_count < 0 {
             bail!("Unexpected negative record count ({record_count})");
         }
-        let record_count = record_count as usize;
 
-        let batch_decode_info = BatchDecodeInfo {
+        let batch_info = BatchDecodeInfo {
             record_count,
             timestamp_type,
             min_offset,
@@ -578,31 +607,47 @@ impl RecordBatchDecoder {
             partition_leader_epoch,
             producer_id,
             producer_epoch,
+            compression,
+            version,
         };
 
-        if let Some(decompress_func) = decompress_func {
-            let mut decompressed_buf = decompress_func(buf, compression)?;
+        Ok((batch_info, buf.clone()))
+    }
 
+    fn decode_new_batch<B: ByteBuf, F>(
+        buf: &mut B,
+        version: i8,
+        records: &mut Vec<Record>,
+        decompress_func: Option<&F>,
+    ) -> Result<Compression>
+    where
+        F: Fn(&mut bytes::Bytes, Compression) -> Result<B>,
+    {
+        let (batch_decode_info, mut records_buf) = Self::decode_batch_header_inner(buf, version)?;
+        let compression = batch_decode_info.compression;
+
+        if let Some(decompress_func) = decompress_func {
+            let mut decompressed_buf = decompress_func(&mut records_buf, compression)?;
             Self::decode_new_records(&mut decompressed_buf, &batch_decode_info, version, records)?;
         } else {
             match compression {
-                Compression::None => cmpr::None::decompress(buf, |buf| {
+                Compression::None => cmpr::None::decompress(&mut records_buf, |buf| {
                     Self::decode_new_records(buf, &batch_decode_info, version, records)
                 })?,
                 #[cfg(feature = "snappy")]
-                Compression::Snappy => cmpr::Snappy::decompress(buf, |buf| {
+                Compression::Snappy => cmpr::Snappy::decompress(&mut records_buf, |buf| {
                     Self::decode_new_records(buf, &batch_decode_info, version, records)
                 })?,
                 #[cfg(feature = "gzip")]
-                Compression::Gzip => cmpr::Gzip::decompress(buf, |buf| {
+                Compression::Gzip => cmpr::Gzip::decompress(&mut records_buf, |buf| {
                     Self::decode_new_records(buf, &batch_decode_info, version, records)
                 })?,
                 #[cfg(feature = "zstd")]
-                Compression::Zstd => cmpr::Zstd::decompress(buf, |buf| {
+                Compression::Zstd => cmpr::Zstd::decompress(&mut records_buf, |buf| {
                     Self::decode_new_records(buf, &batch_decode_info, version, records)
                 })?,
                 #[cfg(feature = "lz4")]
-                Compression::Lz4 => cmpr::Lz4::decompress(buf, |buf| {
+                Compression::Lz4 => cmpr::Lz4::decompress(&mut records_buf, |buf| {
                     Self::decode_new_records(buf, &batch_decode_info, version, records)
                 })?,
                 #[allow(unreachable_patterns)]
@@ -909,9 +954,69 @@ impl Record {
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
+    use bytes::{Bytes, BytesMut};
 
     use super::*;
+
+    fn make_batch(record_count: usize) -> Bytes {
+        let records: Vec<Record> = (0..record_count as i64)
+            .map(|i| Record {
+                transactional: false,
+                control: false,
+                partition_leader_epoch: NO_PARTITION_LEADER_EPOCH,
+                producer_id: NO_PRODUCER_ID,
+                producer_epoch: NO_PRODUCER_EPOCH,
+                sequence: i as i32,
+                timestamp_type: TimestampType::Creation,
+                offset: i,
+                timestamp: i,
+                key: Some(Bytes::from("k")),
+                value: Some(Bytes::from("v")),
+                headers: Default::default(),
+            })
+            .collect();
+        let mut buf = BytesMut::new();
+        RecordBatchEncoder::encode(
+            &mut buf,
+            &records,
+            &RecordEncodeOptions {
+                version: 2,
+                compression: Compression::None,
+            },
+        )
+        .unwrap();
+        buf.freeze()
+    }
+
+    #[test]
+    fn decode_batch_info_empty() {
+        let mut buf = Bytes::new();
+        assert_eq!(
+            Vec::<BatchDecodeInfo>::new(),
+            RecordBatchDecoder::decode_batch_info(&mut buf).unwrap()
+        );
+    }
+
+    #[test]
+    fn decode_batch_info_single_batch() {
+        let mut buf = make_batch(3);
+        let infos = RecordBatchDecoder::decode_batch_info(&mut buf).unwrap();
+        assert_eq!(1, infos.len());
+        assert_eq!(3, infos[0].record_count);
+        assert_eq!(Compression::None, infos[0].compression);
+    }
+
+    #[test]
+    fn decode_batch_info_two_batches() {
+        let mut buf = BytesMut::new();
+        buf.extend_from_slice(&make_batch(2));
+        buf.extend_from_slice(&make_batch(3));
+        let mut buf = buf.freeze();
+        let infos = RecordBatchDecoder::decode_batch_info(&mut buf).unwrap();
+        assert_eq!(2, infos.len());
+        assert_eq!(2, infos[0].record_count);
+        assert_eq!(3, infos[1].record_count);
+    }
 
     #[test]
     fn lookup_header_via_u8_slice() {
@@ -987,6 +1092,8 @@ mod tests {
                 partition_leader_epoch: 0,
                 producer_id: 0,
                 producer_epoch: 0,
+                compression: Compression::None,
+                version: 2,
             },
             2,
         )


### PR DESCRIPTION
Hey 👋 

In our project that uses `kafka-protocol-rs` we have a use case to provide telemetry on the number of records in the record batch. Telemetry is assembled in a completely different phase than handling the records, so I cannot rely on the decoded batch. I also don't want to decode the batch twice because it's too expensive. Right now, we hacked around `fn count_records(batches: &Bytes) -> i32` function that extracts record count from the batches. It would be great if, instead of decoding this info ourselves, we could just use what was already done in kafka-protocol-rs.
Exposing BatchDecodeInfo and `decode_batch_info` would be a nice solution for us.