### PR TITLE
records: replace CRC checksums with crc-fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes ⚠️
+
+* Keep `records::IEEE`, but change its type from `crc::Crc<u32>` to `crc_fast::CrcAlgorithm`
+
+### Features
+
+* Use `crc-fast` 1.10.0 for hardware-accelerated record batch CRC32C checksums
+
+### Dependency updates
+
+* Replace the direct `crc` and `crc32c` dependencies with `crc-fast` 1.10.0
+
 ## 0.18.0
 
 ### Breaking changes ⚠️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,6 @@
 
 * Replace the direct `crc` and `crc32c` dependencies with `crc-fast` 1.10.0
 
-### Tooling
-
-* Use the stable Rust toolchain and Rust 2024 edition
-
 ## 0.18.0
 
 ### Breaking changes ⚠️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 * Replace the direct `crc` and `crc32c` dependencies with `crc-fast` 1.10.0
 
+### Tooling
+
+* Use the stable Rust toolchain and Rust 2024 edition
+
 ## 0.18.0
 
 ### Breaking changes ⚠️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes ⚠️
 
-* Keep `records::IEEE`, but change its type from `crc::Crc<u32>` to `crc_fast::CrcAlgorithm`
+* Remove the public `records::IEEE` CRC helper
 
 ### Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,9 +346,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc"
-version = "3.4.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -360,12 +360,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
-name = "crc32c"
-version = "0.6.8"
+name = "crc-fast"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
- "rustc_version",
+ "crc",
+ "digest",
+ "rustversion",
+ "spin",
 ]
 
 [[package]]
@@ -375,6 +378,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -420,6 +433,15 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "crypto-common",
 ]
 
 [[package]]
@@ -635,6 +657,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1078,7 +1110,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "crc",
- "crc32c",
+ "crc-fast",
  "flate2",
  "indexmap 2.12.1",
  "lz4",
@@ -1624,15 +1656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,12 +1791,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1939,6 +1956,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2293,6 +2316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2416,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,27 +376,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.4.0"
+name = "crc-fast"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "crc32c"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
-dependencies = [
- "rustc_version",
+ "digest",
+ "spin",
 ]
 
 [[package]]
@@ -406,6 +392,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -480,6 +476,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "crypto-common",
 ]
 
 [[package]]
@@ -693,6 +698,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1197,8 +1212,7 @@ version = "0.18.0"
 dependencies = [
  "anyhow",
  "bytes",
- "crc",
- "crc32c",
+ "crc-fast",
  "flate2",
  "indexmap 2.14.0",
  "lz4",
@@ -1683,15 +1697,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,12 +1822,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1990,6 +1989,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2372,6 +2377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,6 +2433,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,13 +44,13 @@ default = ["client", "broker", "gzip", "zstd", "snappy", "lz4"]
 bytes = "1.10.1"
 uuid = "1.3.0"
 indexmap = "2.0.0"
-crc = "3.0.0"
+crc = "3.3.0"
 snap = { version = "1.0.5", optional = true }
 flate2 = { version = "1.0.20", optional = true }
 zstd = { version = "0.13", optional = true }
 lz4 = { version = "1.24", optional = true }
 paste = "1.0.7"
-crc32c = "0.6.4"
+crc-fast = { version = "1.9.0", default-features = false, features = ["std"] }
 anyhow = "1.0.80"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Charlotte McElwain <charlotte.c.mcelwain@gmail.com>",
     "belltoy <belltoy@gmail.com>",
 ]
-edition = "2021"
+edition = "2024"
 license = "MIT/Apache-2.0"
 description = "Implementation of Kafka wire protocol."
 homepage = "https://github.com/tychedelia/kafka-protocol-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,11 @@ default = ["client", "broker", "gzip", "zstd", "snappy", "lz4"]
 bytes = "1.10.1"
 uuid = "1.3.0"
 indexmap = "2.0.0"
-crc = "3.0.0"
 snap = { version = "1.0.5", optional = true }
 flate2 = { version = "1.0.20", optional = true }
 zstd = { version = "0.13", optional = true }
 lz4 = { version = "1.24", optional = true }
-crc32c = "0.6.4"
+crc-fast = { version = "1.10.0", default-features = false, features = ["std"] }
 anyhow = "1.0.80"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Charlotte McElwain <charlotte.c.mcelwain@gmail.com>",
     "belltoy <belltoy@gmail.com>",
 ]
-edition = "2024"
+edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Implementation of Kafka wire protocol."
 homepage = "https://github.com/tychedelia/kafka-protocol-rs"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.89.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "aarch64-unknown-linux-gnu" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.89"
 components = [ "rustfmt", "clippy" ]
 targets = [ "aarch64-unknown-linux-gnu" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88"
+channel = "stable"
 components = [ "rustfmt", "clippy" ]
 targets = [ "aarch64-unknown-linux-gnu" ]

--- a/src/records.rs
+++ b/src/records.rs
@@ -40,8 +40,8 @@
 //! ```
 use anyhow::{anyhow, bail, Result};
 use bytes::{Bytes, BytesMut};
+use crc_fast::{checksum, CrcAlgorithm};
 use crc::{Crc, CRC_32_ISO_HDLC};
-use crc32c::crc32c;
 use indexmap::IndexMap;
 
 use crate::protocol::{
@@ -54,6 +54,11 @@ use std::cmp::Ordering;
 use std::convert::TryFrom;
 /// IEEE (checksum) cyclic redundancy check.
 pub const IEEE: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
+
+#[inline]
+fn crc32c(data: &[u8]) -> u32 {
+    checksum(CrcAlgorithm::Crc32Iscsi, data) as u32
+}
 
 /// The different types of compression supported by Kafka.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/records.rs
+++ b/src/records.rs
@@ -56,8 +56,11 @@ use std::convert::TryFrom;
 pub const IEEE: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
 
 #[inline]
+/// Kafka record batches use CRC32C (Castagnoli), which maps to
+/// `CrcAlgorithm::Crc32Iscsi` in `crc-fast`.
 fn crc32c(data: &[u8]) -> u32 {
-    checksum(CrcAlgorithm::Crc32Iscsi, data) as u32
+    u32::try_from(checksum(CrcAlgorithm::Crc32Iscsi, data))
+        .expect("Crc32Iscsi must fit in u32")
 }
 
 /// The different types of compression supported by Kafka.

--- a/src/records.rs
+++ b/src/records.rs
@@ -56,7 +56,7 @@ use std::convert::TryFrom;
 /// Kafka record batches use CRC32C (Castagnoli), which maps to
 /// `CrcAlgorithm::Crc32Iscsi` in `crc-fast`.
 fn crc32c(data: &[u8]) -> u32 {
-    u32::try_from(checksum(CrcAlgorithm::Crc32Iscsi, data)).expect("Crc32Iscsi must fit in u32")
+    checksum(CrcAlgorithm::Crc32Iscsi, data) as u32
 }
 
 /// The different types of compression supported by Kafka.

--- a/src/records.rs
+++ b/src/records.rs
@@ -51,8 +51,6 @@ use crate::protocol::{
 use super::compression::{self as cmpr, Compressor, Decompressor};
 use std::cmp::Ordering;
 use std::convert::TryFrom;
-/// IEEE (checksum) cyclic redundancy check.
-pub const IEEE: CrcAlgorithm = CrcAlgorithm::Crc32IsoHdlc;
 
 #[inline]
 /// Kafka record batches use CRC32C (Castagnoli), which maps to
@@ -978,11 +976,6 @@ mod tests {
         )
         .unwrap();
         buf.freeze()
-    }
-
-    #[test]
-    fn ieee_uses_crc32_iso_hdlc() {
-        assert_eq!(0xcbf4_3926, checksum(IEEE, b"123456789"));
     }
 
     #[test]

--- a/src/records.rs
+++ b/src/records.rs
@@ -40,8 +40,7 @@
 //! ```
 use anyhow::{anyhow, bail, Result};
 use bytes::{Bytes, BytesMut};
-use crc::{Crc, CRC_32_ISO_HDLC};
-use crc32c::crc32c;
+use crc_fast::{checksum, CrcAlgorithm};
 use indexmap::IndexMap;
 
 use crate::protocol::{
@@ -53,7 +52,14 @@ use super::compression::{self as cmpr, Compressor, Decompressor};
 use std::cmp::Ordering;
 use std::convert::TryFrom;
 /// IEEE (checksum) cyclic redundancy check.
-pub const IEEE: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
+pub const IEEE: CrcAlgorithm = CrcAlgorithm::Crc32IsoHdlc;
+
+#[inline]
+/// Kafka record batches use CRC32C (Castagnoli), which maps to
+/// `CrcAlgorithm::Crc32Iscsi` in `crc-fast`.
+fn crc32c(data: &[u8]) -> u32 {
+    u32::try_from(checksum(CrcAlgorithm::Crc32Iscsi, data)).expect("Crc32Iscsi must fit in u32")
+}
 
 /// The different types of compression supported by Kafka.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -972,6 +978,11 @@ mod tests {
         )
         .unwrap();
         buf.freeze()
+    }
+
+    #[test]
+    fn ieee_uses_crc32_iso_hdlc() {
+        assert_eq!(0xcbf4_3926, checksum(IEEE, b"123456789"));
     }
 
     #[test]

--- a/src/records.rs
+++ b/src/records.rs
@@ -40,7 +40,7 @@
 //! ```
 use anyhow::{anyhow, bail, Result};
 use bytes::{Bytes, BytesMut};
-use crc_fast::{checksum, CrcAlgorithm};
+use crc_fast::crc32_iscsi;
 use indexmap::IndexMap;
 
 use crate::protocol::{
@@ -54,9 +54,9 @@ use std::convert::TryFrom;
 
 #[inline]
 /// Kafka record batches use CRC32C (Castagnoli), which maps to
-/// `CrcAlgorithm::Crc32Iscsi` in `crc-fast`.
+/// `crc_fast::crc32_iscsi`.
 fn crc32c(data: &[u8]) -> u32 {
-    checksum(CrcAlgorithm::Crc32Iscsi, data) as u32
+    crc32_iscsi(data)
 }
 
 /// The different types of compression supported by Kafka.
@@ -976,6 +976,22 @@ mod tests {
         )
         .unwrap();
         buf.freeze()
+    }
+
+    #[test]
+    fn crc32c_matches_standard_check_value() {
+        assert_eq!(0xe306_9283, crc32c(b"123456789"));
+    }
+
+    #[test]
+    fn encoded_batch_contains_crc32c_for_batch_content() {
+        let batch = make_batch(1);
+        let crc_start = MAGIC_BYTE_OFFSET + 1;
+        let content_start = crc_start + std::mem::size_of::<u32>();
+        let supplied_crc = u32::from_be_bytes(batch[crc_start..content_start].try_into().unwrap());
+        let expected_crc = crc32c(&batch[content_start..]);
+
+        assert_eq!(expected_crc, supplied_crc);
     }
 
     #[test]

--- a/src/records.rs
+++ b/src/records.rs
@@ -979,11 +979,6 @@ mod tests {
     }
 
     #[test]
-    fn crc32c_matches_standard_check_value() {
-        assert_eq!(0xe306_9283, crc32c(b"123456789"));
-    }
-
-    #[test]
     fn encoded_batch_contains_crc32c_for_batch_content() {
         let batch = make_batch(1);
         let crc_start = MAGIC_BYTE_OFFSET + 1;


### PR DESCRIPTION
## Summary

- Replace record batch CRC32C calculation with `crc-fast` 1.10.0.
- Replace the direct `crc` and `crc32c` dependencies with `crc-fast`.
- Remove the public `records::IEEE` CRC helper.
- Document the CRC-specific changes under `Unreleased` in `CHANGELOG.md`.
- Merge the latest `main`, including the Rust 1.89/clippy cleanup from #190.

## Breaking change

- `records::IEEE` is removed.

## Validation

- `cargo hack --feature-powerset clippy --all-targets --locked -- -D warnings` with `rustc 1.89.0` / `cargo 1.89.0`
- `cargo test records::tests --locked` with `rustc 1.89.0` / `cargo 1.89.0`
- `cargo fmt --all --check` with `rustc 1.89.0` / `cargo 1.89.0`
- `git diff --check`

## Related PR

- #190 fixed the separate feature-powerset clippy warning issue and is now included via the latest `main` merge.

Refs #154