### PR TITLE
fix: prevent OOM from untrusted record_count in RecordBatchDecoder

### DIFF
--- a/src/records.rs
+++ b/src/records.rs
@@ -476,7 +476,7 @@ impl RecordBatchDecoder {
         version: i8,
         records: &mut Vec<Record>,
     ) -> Result<()> {
-        records.reserve(batch_decode_info.record_count);
+        records.reserve(batch_decode_info.record_count.min(buf.remaining()));
         for _ in 0..batch_decode_info.record_count {
             records.push(Record::decode_new(buf, batch_decode_info, version)?);
         }


### PR DESCRIPTION
## Problem

`RecordBatchDecoder::decode_records` calls `records.reserve(batch_decode_info.record_count)` using an attacker-controlled `record_count` read from the wire. A malicious or malformed record batch can advertise a huge `record_count` while carrying little actual data, causing a large up-front allocation and a potential out-of-memory denial of service before any records are decoded.

## Fix

Cap the reserved capacity to the number of remaining bytes in the buffer:

```rust
records.reserve(batch_decode_info.record_count.min(buf.remaining()));
```

Each record requires at least one byte to decode, so `buf.remaining()` is a safe upper bound on the number of records that could actually be present. Legitimate batches are unaffected (the reserve still pre-sizes the vector), while a bogus `record_count` can no longer trigger an oversized allocation. Decoding of the actual records is unchanged and still errors cleanly if the buffer is truncated.
