### PR TITLE
chore: update non-CRC dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Dependency updates
+
+* Update `Cargo.toml` dependency versions: `bytes` 1.12.1, `uuid` 1.26.0, `indexmap` 2.14.1, `snap` 1.1.2, `flate2` 1.1.10, `lz4` 1.28.1, and `anyhow` 1.0.104
+* Update `protocol_codegen/Cargo.toml` dependency versions: `failure` 0.1.8, `serde` 1.0.229, `serde_json` 1.0.151, `serde_plain` 1.0.2, and `json_comments` 0.2.2
+
 ## 0.18.0
 
 ### Breaking changes ⚠️

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "object",
  "rustc-demangle",
  "windows-link",
@@ -529,7 +529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -583,12 +583,13 @@ checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -760,7 +761,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1087,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -1200,7 +1201,7 @@ dependencies = [
  "crc",
  "crc32c",
  "flate2",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "lz4",
  "snap",
  "testcontainers",
@@ -1298,6 +1299,15 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1701,7 +1711,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1910,7 +1920,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.1.0",
@@ -1959,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -2311,7 +2321,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -2409,9 +2419,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2843,6 +2853,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,16 +41,16 @@ lz4 = ["dep:lz4"]
 default = ["client", "broker", "gzip", "zstd", "snappy", "lz4"]
 
 [dependencies]
-bytes = "1.10.1"
-uuid = "1.3.0"
-indexmap = "2.0.0"
+bytes = "1.12.1"
+uuid = "1.26.0"
+indexmap = "2.14.1"
 crc = "3.0.0"
-snap = { version = "1.0.5", optional = true }
-flate2 = { version = "1.0.20", optional = true }
+snap = { version = "1.1.2", optional = true }
+flate2 = { version = "1.1.10", optional = true }
 zstd = { version = "0.13", optional = true }
-lz4 = { version = "1.24", optional = true }
+lz4 = { version = "1.28.1", optional = true }
 crc32c = "0.6.4"
-anyhow = "1.0.80"
+anyhow = "1.0.104"
 
 [dev-dependencies]
 testcontainers = { version = "0.28.0", features = ["blocking", "watchdog"] }

--- a/protocol_codegen/Cargo.toml
+++ b/protocol_codegen/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-failure = "0.1.6"
+failure = "0.1.8"
 Inflector = { version = "0.11.4", default-features = false }
-serde = { version = "1.0.104", features = ["derive"] }
-serde_json = "1.0.48"
-serde_plain = "1.0.1"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
+serde_plain = "1.0.2"
 parse-display = "0.11.0"
-json_comments = "0.2.0"
+json_comments = "0.2.2"
 assert-json-diff = "2.0.2"
 git2 = "0.21"


### PR DESCRIPTION
## Summary

- Update non-CRC dependency versions in `Cargo.toml`.
- Update dependency versions in `protocol_codegen/Cargo.toml`.
- Refresh `Cargo.lock` for those dependency updates.
- Document the dependency updates under `Unreleased` in `CHANGELOG.md`.

## Notes

- This PR intentionally leaves `crc` and `crc32c` unchanged.
- CRC-related changes remain scoped to #155.

## Validation

- `cargo +stable check`
- `cargo +stable check --locked`
- `cargo +stable fmt --all --check`
- `git diff --check`